### PR TITLE
docs: add tmux and agentic development environment guides

### DIFF
--- a/_posts/2026/07/2026-07-12-building-an-agentic-development-environment.md
+++ b/_posts/2026/07/2026-07-12-building-an-agentic-development-environment.md
@@ -1,0 +1,492 @@
+---
+title: 여러 AI 코딩 에이전트를 위한 Agentic Development Environment 구축하기
+date: 2026-07-12 02:31:00 +0900
+author: kkamji
+categories: [AI, Development Environment]
+tags: [ai-agent, agentic-development, cmux, ghostty, tmux, claude-code, codex, hermes-agent, macos, devsecops]
+comments: true
+image:
+  path: /assets/img/kkam-img/kkam.webp
+---
+
+Claude Code, Codex, Hermes처럼 터미널에서 동작하는 AI 코딩 에이전트를 동시에 사용하면 실행 능력은 빠르게 늘어납니다. 그러나 작업 수가 늘어날수록 더 큰 병목은 모델 성능이 아니라 사람이 현재 상황을 파악하고 안전하게 개입하는 과정에서 생깁니다. 어느 저장소에서 어떤 에이전트가 일하는지, 승인을 기다리는 작업이 무엇인지, 같은 파일을 두 에이전트가 수정하고 있지는 않은지를 계속 기억해야 하기 때문입니다.
+
+이 글에서는 MacBook 로컬 환경만을 대상으로, DevSecOps 엔지니어가 여러 AI 코딩 에이전트를 운영하기 위한 Agentic Development Environment를 설계한 과정을 정리합니다. 최종 구성은 cmux를 workspace와 attention cockpit으로 사용하고, Ghostty는 fallback terminal로 남기며, tmux는 cmux 종료 후에도 살아 있어야 하는 장기 interactive process에만 제한적으로 적용하는 구조입니다.
+
+> **TL;DR**  
+> - 문제의 핵심은 터미널 개수가 아니라 task location, status, ownership을 한눈에 파악하기 어렵다는 점입니다.  
+> - cmux는 macOS에서 workspace sidebar, split pane, notification panel을 한곳에 제공하므로 primary workspace와 attention cockpit으로 사용합니다.  
+> - Ghostty는 빠르고 네이티브한 fallback terminal로 유지하지만, 병렬 에이전트의 상태판 역할까지 맡기지는 않습니다.  
+> - tmux는 cmux가 닫혀도 계속 실행되어야 하는 장기 interactive process에만 사용합니다. native subagent와 one-shot worker에는 tmux가 필요하지 않습니다.  
+> - cmux session restore는 layout과 metadata를 복원하며, 지원되는 에이전트는 native session ID로 resume할 수 있습니다. 임의의 live process state를 보존하는 기능은 아닙니다.  
+> - 로컬 tmux도 MacBook reboot 후에는 종료됩니다. 에이전트의 native resume은 대화와 작업 맥락을 다시 여는 recovery path이지, 실행 중이던 프로세스의 checkpoint가 아닙니다.  
+> - workspace group은 정리 기능일 뿐 보안 경계가 아닙니다. 권한과 secret 격리는 별도 계정, sandbox, container, VM 같은 실행 경계에서 설계해야 합니다.  
+{: .prompt-info}
+
+---
+
+## 1. 문제 정의: 실행 창보다 attention routing이 어렵다
+
+처음에는 Ghostty 창과 tab을 여러 개 열고 Claude Code, Codex, Hermes를 각각 실행했습니다. 작업이 두세 개일 때는 충분했습니다. Ghostty는 macOS native tab과 split을 제공하고 window state recovery도 지원하므로 일반 terminal로서는 완성도가 높습니다.
+
+문제는 병렬 작업이 늘어난 뒤 나타났습니다.
+
+- 어떤 tab이 어떤 repository와 worktree를 가리키는지 기억해야 합니다.
+- 에이전트가 실행 중인지, 입력을 기다리는지, 완료했는지 직접 순회해야 합니다.
+- 같은 이름의 shell과 agent process가 여러 창에 흩어집니다.
+- Claude Code와 Codex desktop app을 함께 열면 terminal, editor, chat surface가 더 분리됩니다.
+- Hermes Desktop은 개인 작업 방식에 맞는 primary cockpit이 아니었습니다.
+- 승인 요청과 완료 알림이 여러 앱에 흩어져 중요한 신호가 묻힙니다.
+
+따라서 목표는 terminal emulator를 하나 더 고르는 것이 아닙니다. 다음 질문에 빠르게 답할 수 있는 운영 화면을 만드는 것입니다.
+
+1. 지금 어떤 task가 실행 중입니까?
+2. 각 task의 repository, branch, worktree는 어디입니까?
+3. 어떤 agent가 다음 입력이나 승인을 기다리고 있습니까?
+4. 어느 task가 파일을 쓸 권한을 갖고 있습니까?
+5. 앱이 닫히거나 MacBook이 재시작되면 무엇이 살아남고 무엇을 복구해야 합니까?
+
+이 관점에서는 Agentic Development Environment를 세 층으로 나누는 편이 명확합니다.
+
+| 계층 | 책임 | 이번 선택 |
+| :--- | :--- | :--- |
+| Workspace와 attention | task 위치, 상태, 알림, 이동 | cmux |
+| Terminal rendering | shell, TUI, text rendering | cmux의 Ghostty 기반 terminal, Ghostty fallback |
+| Process lifetime | terminal app 종료와 process 수명 분리 | 필요한 경우에만 tmux |
+
+---
+
+## 2. 설계 원칙
+
+도구 비교 전에 운영 원칙을 먼저 고정했습니다. 원칙이 없으면 모든 terminal feature가 필수처럼 보이고, 결국 multiplexing layer만 중복됩니다.
+
+### 2.1. Task가 workspace의 기본 단위다
+
+agent 종류가 아니라 task를 기준으로 workspace를 만듭니다. 하나의 task workspace 안에서 필요한 agent, test shell, log pane을 함께 둡니다. Claude Code workspace와 Codex workspace를 별도로 만드는 방식은 도구 중심 분류이므로, 같은 task의 context가 다시 흩어질 수 있습니다.
+
+### 2.2. Attention 신호는 사람이 행동해야 할 때만 보낸다
+
+모든 command completion을 알림으로 보내면 attention cockpit이 log viewer로 변합니다. 알림은 승인 필요, 사용자 입력 필요, 실패, 최종 완료처럼 사람이 실제로 판단해야 하는 상태로 제한합니다.
+
+### 2.3. Process persistence와 context recovery를 구분한다
+
+tmux detach는 tmux server가 살아 있는 동안 내부 process를 계속 실행합니다. 반면 agent resume은 저장된 agent session을 다시 여는 기능입니다. 둘은 다음처럼 목적이 다릅니다.
+
+| 기능 | 보존 대상 | 보존하지 않는 것 |
+| :--- | :--- | :--- |
+| cmux layout restore | window, workspace, pane, working directory, best-effort scrollback | 임의 process memory와 실행 지점 |
+| agent native resume | 지원 agent의 session ID와 대화 맥락 | 실행 중 child process의 memory와 open file descriptor |
+| tmux detach와 attach | 살아 있는 tmux server 내부의 terminal process | MacBook reboot 이후의 local process |
+
+### 2.4. Organization과 isolation을 구분한다
+
+workspace, group, tab, pane은 사람이 context를 정리하기 위한 UI 단위입니다. 이 이름이나 색상은 filesystem permission, network policy, credential boundary를 만들지 않습니다. 보안 통제는 실행 계정, worktree, container, VM, sandbox, cloud IAM처럼 실제 권한을 강제하는 계층에서 수행해야 합니다.
+
+---
+
+## 3. 후보 도구와 trade-off
+
+이번 비교에서는 MacBook local environment만 다룹니다. Warp, JetBrains 계열 도구, iTerm2는 개인 선호에 따라 후보에서 제외했습니다. 이 제외는 기능의 우열에 대한 평가가 아니라 탐색 범위를 줄이기 위한 제약입니다.
+
+### 3.1. Ghostty 단독
+
+Ghostty는 macOS native UI, tab, split, window state recovery, secure input API를 지원합니다. 일상 shell과 fallback terminal로 사용하기에 적합합니다. 이미 Ghostty에 익숙하다면 별도의 terminal syntax를 학습하지 않고도 빠르게 작업할 수 있습니다.
+
+다만 이번 문제는 terminal rendering이 아니라 여러 agent의 task status와 attention routing입니다. Ghostty의 tab과 split만으로도 배치할 수 있지만, task가 늘면 tab 이름과 창 위치를 사람이 계속 관리해야 합니다. 따라서 Ghostty를 버리는 것이 아니라 역할을 fallback terminal로 좁혔습니다.
+
+### 3.2. cmux
+
+cmux는 Ghostty 기반 terminal에 vertical workspace sidebar, split pane, notification panel, CLI와 socket API를 결합한 macOS app입니다. workspace sidebar에서 working directory와 branch 같은 context를 보고, unread notification이 있는 workspace로 이동할 수 있다는 점이 이번 문제와 직접 맞닿아 있습니다.
+
+선택 이유는 모든 기능이 더 우수해서가 아닙니다. task location과 attention signal을 한 화면에서 연결하는 비용이 가장 낮았기 때문입니다. 반대로 다음 trade-off도 있습니다.
+
+- macOS 전용이므로 cross-platform configuration을 그대로 재사용하기 어렵습니다.
+- 빠르게 개발되는 도구이므로 behavior와 shortcut은 version에 따라 달라질 수 있습니다.
+- workspace hierarchy와 session restore 개념을 정확히 이해하지 않으면 process persistence를 과대평가할 수 있습니다.
+- notification hook과 project-local command는 편리하지만, 실행되는 command와 노출되는 text를 검토해야 합니다.
+
+즉 cmux는 process supervisor나 security sandbox가 아니라 workspace와 attention을 관리하는 cockpit으로 채택합니다.
+
+### 3.3. tmux
+
+tmux는 terminal multiplexer server와 client를 분리합니다. client를 detach해도 server와 그 안의 program이 계속 실행되므로, terminal app을 닫아도 유지해야 하는 interactive process에 적합합니다.
+
+그러나 모든 agent를 tmux 안에 넣으면 cmux와 tmux 양쪽에 session, window, pane 개념이 생깁니다. shortcut layer가 겹치고 현재 위치를 파악하는 비용도 늘어납니다. 따라서 tmux는 다음 질문에 `yes`라고 답할 때만 사용합니다.
+
+> cmux를 지금 완전히 종료해도 이 interactive process가 반드시 계속 살아 있어야 합니까?  
+
+예를 들어 장시간 관찰해야 하는 local log tail, REPL, test watch, foreground dev server가 이에 해당할 수 있습니다. 반대로 native subagent, agent가 내부적으로 생성한 worker, 몇 분 안에 끝나는 one-shot analysis는 parent agent의 lifecycle과 task model로 관리하면 되므로 tmux가 필요하지 않습니다.
+
+tmux server도 local process입니다. MacBook이 reboot되거나 tmux server가 종료되면 session은 사라집니다. tmux는 app close boundary를 넘기기 위한 도구이지 reboot checkpoint가 아닙니다.
+
+### 3.4. Zellij
+
+Zellij는 session manager와 session resurrection을 기본 제공하고, layout, pane, tab, command를 serialize합니다. 종료된 session을 복원할 때 command를 자동 실행하지 않고 확인을 요구하는 기본 동작도 안전 측면에서 의미가 있습니다.
+
+그러나 resurrection은 process memory를 되살리는 것이 아니라 layout과 command를 기반으로 재구성하는 방식입니다. 이번 목표에서는 cmux의 macOS native sidebar와 agent attention 흐름을 우선했기 때문에 primary tool로 고르지 않았습니다. terminal 내부에서 더 풍부한 session UI와 declarative layout을 원하는 경우에는 충분히 검토할 대안입니다.
+
+### 3.5. WezTerm
+
+WezTerm은 Lua configuration과 multiplexing domain을 제공합니다. local 또는 SSH domain에 연결해 window와 tab을 관리할 수 있어 terminal automation과 cross-platform consistency를 중시하면 강력한 선택입니다.
+
+다만 이번 의사결정의 우선순위는 programmable terminal 자체보다 여러 coding agent의 attention을 macOS native sidebar에서 추적하는 것이었습니다. Lua 기반으로 원하는 status와 notification을 직접 구성할 수 있지만, 그만큼 초기 설계와 유지 관리 비용을 부담해야 합니다.
+
+### 3.6. kitty
+
+kitty는 tab, window, remote control API, desktop notification 기능을 제공합니다. script로 window를 제어하거나 notification을 세밀하게 다루려는 경우 유연합니다. remote control을 활성화할 때는 허용 범위와 password policy를 함께 검토해야 합니다.
+
+이번에는 agent task를 workspace 단위로 보여 주는 기본 UX와 macOS cockpit을 우선했기 때문에 선택하지 않았습니다. 기존 kitty automation 자산이 많다면 cmux로 옮기는 비용보다 kitty 구성을 확장하는 편이 더 나을 수 있습니다.
+
+### 3.7. 비교 결과
+
+| 후보 | 강점 | 이번 범위의 제약 | 역할 |
+| :--- | :--- | :--- | :--- |
+| Ghostty | native macOS UI, 빠른 terminal, tab과 split | agent attention을 task 단위로 모으는 상태판은 직접 운영 | fallback terminal |
+| cmux | vertical workspace, notification panel, Ghostty 기반 terminal | macOS 전용, session restore 범위 이해 필요 | primary cockpit |
+| tmux | client 종료 후에도 server 내부 process 유지 | reboot persistence 없음, 중첩 multiplexing 비용 | 선택적 persistence layer |
+| Zellij | session manager, layout과 command resurrection | 현재 목표보다 terminal 내부 session 관리에 초점 | 대안 |
+| WezTerm | Lua automation, multiplexing domain | 직접 구성하고 유지할 범위가 큼 | 대안 |
+| kitty | remote control, notification, scriptability | task cockpit을 별도로 설계해야 함 | 대안 |
+
+---
+
+## 4. 최종 아키텍처
+
+```text
+MacBook local environment
+|
++-- cmux: primary workspace and attention cockpit
+|   |
+|   +-- Workspace Group: project or operating context
+|       |
+|       +-- Workspace: one task and one worktree
+|       |   +-- Pane: primary writer agent
+|       |   +-- Pane: tests, diff, logs
+|       |   +-- Native subagent or one-shot worker
+|       |
+|       +-- Workspace: another task and another worktree
+|           +-- Claude Code, Codex, or Hermes
+|           +-- tmux only when a live interactive process
+|               must survive cmux closing
+|
++-- Ghostty: fallback terminal
+    +-- recovery, troubleshooting, or cmux-independent shell
+```
+
+핵심은 cmux와 tmux의 책임을 겹치지 않는 것입니다.
+
+- cmux는 사람이 task를 찾고 attention을 배분하는 control plane입니다.
+- 각 workspace는 하나의 task와 하나의 worktree를 가리킵니다.
+- agent CLI는 기본적으로 cmux terminal에서 직접 실행합니다.
+- tmux는 명시적인 process lifetime 요구가 있을 때만 한 단계 아래에 둡니다.
+- Ghostty는 cmux 장애, 설정 오류, 복구 작업에 사용할 독립 terminal입니다.
+
+이 구조에서는 Claude Code, Codex, Hermes desktop app을 primary surface로 사용하지 않습니다. agent interaction을 cmux terminal로 모아 app switching과 notification fragmentation을 줄입니다. 단, 각 agent의 native session과 resume 기능은 그대로 활용합니다.
+
+---
+
+## 5. Workspace와 session 운영 규칙
+
+도구를 설치하는 것보다 이름과 소유권 규칙을 일관되게 적용하는 일이 더 중요합니다. 다음 규칙은 sidebar만 보고도 task identity와 write ownership을 판단할 수 있게 만드는 최소 규칙입니다.
+
+### 5.1. 이름 규칙
+
+| 대상 | 형식 | 예시 |
+| :--- | :--- | :--- |
+| Workspace Group | `<project>-<context>` | `platform-prod-readonly` |
+| Workspace | `<type>-<task>-<agent>-<state>` | `fix-auth-codex-waiting` |
+| Worktree path | `<type>-<short-description>` | `fix-auth-timeout` |
+| Branch | `<type>/<short-description>` | `fix/auth-timeout` |
+| tmux session | `<project>-<task>-<process>` | `api-auth-test-watch` |
+
+state는 `running`, `waiting`, `review`, `done`, `blocked`처럼 작은 집합으로 제한합니다. 이름이 길어지면 issue number를 넣고 설명을 줄입니다.
+
+```text
+fix-142-codex-running
+feat-207-claude-review
+docs-agent-env-hermes-waiting
+```
+
+workspace 이름은 dashboard label입니다. 신뢰할 수 있는 실제 identity는 working directory, Git branch, worktree status입니다. agent에게 mutation을 허용하기 전 다음 세 값을 확인합니다.
+
+```shell
+pwd
+git branch --show-current
+git status --short
+```
+
+### 5.2. Single-writer rule
+
+동일한 task와 worktree에는 동시에 한 명의 primary writer만 둡니다.
+
+1. primary writer만 source file을 수정합니다.
+2. reviewer agent는 diff와 test result를 읽고 제안만 작성합니다.
+3. subagent가 file을 수정해야 한다면 서로 겹치지 않는 file ownership을 사전에 지정합니다.
+4. ownership을 나누기 어렵다면 별도 worktree와 branch를 만듭니다.
+5. writer가 바뀔 때는 현재 diff, 검증 결과, 남은 작업을 handoff한 뒤 기존 writer의 mutation을 중지합니다.
+
+native subagent는 parent agent가 관리하는 실행 단위입니다. 별도 tmux session을 강제하지 않습니다. one-shot worker도 결과를 반환하고 종료하는 것이 정상 lifecycle이므로 tmux를 추가하지 않습니다. tmux 사용 여부는 agent 종류가 아니라 process가 cmux 종료 이후에도 살아 있어야 하는지로 결정합니다.
+
+### 5.3. Workspace group은 보안 경계가 아니다
+
+cmux 공식 문서의 workspace group은 sidebar에서 workspace를 접고 펼치는 organization 기능입니다. 이름, icon, color, membership이 저장되지만 별도 filesystem namespace나 credential boundary를 제공한다고 보아서는 안 됩니다.
+
+예를 들어 `company` group과 `personal` group을 나누어도 같은 macOS user로 실행한 process는 해당 user가 가진 파일과 credential에 접근할 수 있습니다. 다음 통제는 별도로 적용해야 합니다.
+
+- 회사와 개인 credential의 profile, keychain item, environment variable 분리
+- production 접근은 read-only profile을 기본값으로 사용
+- mutation 전 account, cluster context, target repository 확인
+- 민감 작업은 container, VM, sandbox 또는 별도 OS account로 실행
+- agent가 읽을 필요가 없는 secret은 environment와 working directory에서 제거
+
+group은 실수를 줄이는 시각적 guardrail로는 유용하지만, 공격이나 권한 오용을 막는 security control은 아닙니다.
+
+---
+
+## 6. Session restore와 process lifetime을 정확히 이해하기
+
+cmux는 relaunch 시 window, workspace, pane layout, working directory, best-effort terminal scrollback, browser state를 복원합니다. 지원되는 coding agent는 hook이 native session ID를 기록한 경우 해당 agent의 resume command로 session을 다시 열 수 있습니다.
+
+여기서 `resume`이라는 단어를 process checkpoint로 해석하면 안 됩니다.
+
+```text
+Before cmux closes
+  agent process + child processes + terminal state
+
+After cmux relaunch
+  restored layout + new terminal process
+  + optional native agent resume command
+```
+
+임의의 shell, vim, tmux, 기타 TUI process가 실행 중이던 instruction과 memory state를 cmux가 저장하는 것은 아닙니다. terminal scrollback도 best-effort이므로 source of truth로 사용하지 않습니다. 중요한 결정, command, test result는 repository 문서나 task note에 남겨야 합니다.
+
+지원 agent의 resume도 recovery path입니다. 대화 history와 agent context를 다시 열 수는 있지만, 종료 순간 실행 중이던 build process, network connection, foreground command가 이어서 실행된다고 가정해서는 안 됩니다. 복구 후에는 다음 순서로 상태를 재확인합니다.
+
+```shell
+pwd
+git branch --show-current
+git status --short
+git diff --check
+```
+
+이후 task note와 test result를 확인하고 필요한 command를 새로 실행합니다.
+
+### 6.1. 언제 tmux를 사용하는가
+
+| 상황 | tmux | 이유 |
+| :--- | :---: | :--- |
+| 10분 이상 실행되는 interactive test watcher를 cmux 종료 후에도 유지 | 사용 | app close와 process lifetime 분리 필요 |
+| foreground dev server를 유지한 채 cmux를 재시작 | 사용 | tmux server가 process를 계속 관리 |
+| Claude Code native subagent | 미사용 | parent agent lifecycle에서 관리 |
+| Codex one-shot review | 미사용 | 결과 반환 후 종료가 정상 |
+| 짧은 build 또는 lint | 미사용 | 재실행 비용이 낮음 |
+| reboot 이후 local process 유지 | 해결 불가 | local tmux server도 reboot 시 종료 |
+
+필요한 경우에만 이름이 있는 session을 만듭니다.
+
+```shell
+tmux new -As api-auth-test-watch
+tmux ls
+tmux attach -t api-auth-test-watch
+```
+
+cmux를 닫기 전 tmux client를 detach하면 tmux server 내부 process는 계속 실행됩니다. 그러나 MacBook reboot 뒤에는 `tmux attach`로 기존 local session에 돌아갈 수 없습니다. 이 경우 repository state와 task note, agent native resume을 이용해 작업을 재구성합니다.
+
+---
+
+## 7. Notification과 privacy boundary
+
+attention cockpit은 알림이 정확할 때만 생산성을 높입니다. 동시에 notification title과 body는 lock screen, Notification Center, screen sharing 화면에 노출될 수 있으므로 secret과 고객 정보를 담지 않아야 합니다.
+
+### 7.1. 알림 정책
+
+| Event | Desktop notification | Sidebar unread | 권장 message |
+| :--- | :---: | :---: | :--- |
+| 승인 필요 | Yes | Yes | `Approval required` |
+| 사용자 입력 필요 | Yes | Yes | `Input required` |
+| 실패 또는 blocked | Yes | Yes | `Task blocked` |
+| 최종 완료 | 선택 | Yes | `Task completed` |
+| 개별 tool 완료 | No | No | 알림 없음 |
+| 일반 progress | No | 선택 | 상태 이름만 갱신 |
+
+cmux는 focused window, active workspace, notification panel이 열린 경우 desktop alert를 억제합니다. 이 기본 behavior에만 의존하지 않고 macOS Focus mode와 notification preview도 함께 조정합니다.
+
+### 7.2. 알림에 넣지 않을 정보
+
+- prompt 원문
+- source code와 diff
+- customer name, incident detail, internal hostname
+- access token, credential path, secret value
+- production resource identifier 전체
+- agent가 읽은 file content
+
+알림에는 `task ID`, `agent`, `action required` 정도만 넣고, 상세 내용은 해당 workspace를 열어 확인합니다. 예시는 다음과 같습니다.
+
+```text
+Title: fix-142-codex
+Body: Approval required
+```
+
+### 7.3. 실행 권한 경계
+
+notification hook과 automation command는 shell command를 실행할 수 있으므로 code와 동일하게 검토합니다. project-local configuration을 신뢰하기 전에 repository owner와 변경 diff를 확인하고, 외부 입력을 command string에 직접 연결하지 않습니다. remote control이나 socket API를 활성화하는 도구는 접근 범위와 credential policy를 최소화합니다.
+
+Ghostty fallback에는 필요한 경우 macOS Secure Keyboard Entry를 사용합니다. 다만 secure input은 key event 보호 기능이지 agent가 이미 접근할 수 있는 file, environment variable, terminal output을 격리하는 기능은 아닙니다.
+
+---
+
+## 8. 1주 practical pilot
+
+처음부터 모든 workflow를 이전하지 않고 1주 동안 실제 task로 검증합니다. pilot의 목적은 cmux 사용 시간을 늘리는 것이 아니라 task discovery time과 missed attention, writer collision을 줄이는지 측정하는 것입니다.
+
+### 8.1. Day 1: Baseline 수집
+
+- 기존 Ghostty 중심 방식으로 3개 이상 병렬 task를 수행합니다.
+- task 위치를 찾는 데 걸린 시간을 10회 측정합니다.
+- 승인 또는 입력 대기 상태를 5분 넘게 놓친 횟수를 기록합니다.
+- 잘못된 repository, branch, worktree에서 command를 실행한 횟수를 기록합니다.
+
+### 8.2. Day 2: 최소 구조 적용
+
+- cmux에 project별 workspace group을 만듭니다.
+- task별 workspace와 worktree를 1:1로 연결합니다.
+- workspace name에 task, agent, state를 표시합니다.
+- Ghostty는 fallback window 하나만 유지합니다.
+
+### 8.3. Day 3: Single-writer 검증
+
+- 두 개 이상의 agent를 동시에 사용하되 task별 primary writer를 한 명으로 제한합니다.
+- reviewer는 read-only prompt와 diff review만 수행합니다.
+- file ownership 충돌과 예상치 못한 diff가 발생했는지 기록합니다.
+
+### 8.4. Day 4: Attention tuning
+
+- approval, input required, blocked, completed만 알림 대상으로 설정합니다.
+- notification body에서 민감한 text를 제거합니다.
+- 불필요한 notification 수와 놓친 notification 수를 각각 기록합니다.
+
+### 8.5. Day 5: Failure drill
+
+- 작업 state를 기록한 뒤 cmux를 정상 종료하고 다시 실행합니다.
+- layout, working directory, scrollback, agent resume 결과를 구분해 확인합니다.
+- native resume 이후 `pwd`, branch, status, diff를 재검증합니다.
+- 임의의 live process가 복원되지 않는다는 전제로 recovery runbook을 점검합니다.
+
+### 8.6. Day 6: tmux 경계 검증
+
+- 장기 interactive process 하나만 tmux에서 실행합니다.
+- tmux client를 detach한 뒤 cmux를 종료하고 process 생존을 확인합니다.
+- 일반 agent task와 one-shot worker에는 tmux를 사용하지 않습니다.
+- 중첩 shortcut과 navigation overhead를 기록합니다.
+
+### 8.7. Day 7: 결과 평가
+
+pilot 전후 지표를 비교하고 다음 기준으로 채택 여부를 결정합니다.
+
+| 지표 | 성공 기준 | 실패 신호 |
+| :--- | :--- | :--- |
+| Task discovery time | median 10초 이하 | baseline 대비 개선 없음 |
+| Missed attention | 5분 초과 대기 1회 이하 | 알림이 있어도 반복적으로 놓침 |
+| Wrong-context command | 0회 | 다른 repository나 branch에서 실행 |
+| Writer collision | 0회 | 같은 file에 동시 mutation 발생 |
+| Notification precision | action이 필요한 알림 80% 이상 | progress 알림이 대부분을 차지 |
+| Recovery clarity | 5분 안에 task state 재구성 | live process 복원 여부를 판단하지 못함 |
+| tmux selectivity | 장기 process에만 사용 | 모든 agent에 관성적으로 적용 |
+
+다음 중 하나라도 발생하면 pilot을 실패로 보고 구성을 축소하거나 대안을 재검토합니다.
+
+- wrong-context command가 한 번이라도 발생했는데 naming과 preflight로 방지되지 않습니다.
+- notification에 secret 또는 민감 정보가 노출됩니다.
+- cmux와 tmux의 중첩이 task navigation을 더 느리게 만듭니다.
+- session restore를 live process persistence로 오해해 작업 손실이 발생합니다.
+- 1주 후에도 workspace state를 수동으로 유지하는 비용이 이득보다 큽니다.
+
+실패 시 rollback은 단순합니다. agent CLI와 repository는 그대로 두고 primary terminal을 Ghostty로 되돌립니다. tmux는 실제 장기 process session만 유지하며, cmux 전용 workspace와 notification 설정은 비활성화합니다.
+
+---
+
+## 9. Daily operation cheat sheet
+
+### 9.1. 작업 시작
+
+```text
+1. task 전용 worktree와 branch 확인
+2. cmux workspace 생성 및 이름 지정
+3. pwd, branch, status 확인
+4. primary writer 한 명 지정
+5. agent 실행
+```
+
+### 9.2. 병렬 worker 추가
+
+```text
+1. 결과만 필요한 one-shot인지 확인
+2. write가 필요하면 file ownership 분리
+3. ownership이 겹치면 별도 worktree 사용
+4. native subagent에는 tmux를 추가하지 않음
+```
+
+### 9.3. 장기 process 시작
+
+```shell
+# cmux 종료 후에도 살아 있어야 할 때만 사용
+tmux new -As <project>-<task>-<process>
+
+# detach: Ctrl-b d
+tmux ls
+```
+
+### 9.4. 작업 복구
+
+```text
+1. cmux layout restore와 process restore를 구분
+2. 지원 agent는 native session resume 확인
+3. pwd, branch, status, diff 재확인
+4. task note에서 마지막 검증 결과 확인
+5. 종료된 command는 안전성을 검토한 뒤 재실행
+```
+
+### 9.5. 작업 종료
+
+```text
+1. test, lint, build 결과 기록
+2. git diff와 status 확인
+3. workspace state를 done 또는 blocked로 갱신
+4. 불필요한 tmux session 종료
+5. 민감한 notification과 scrollback 정리
+```
+
+---
+
+## 10. 마치며
+
+여러 AI 코딩 에이전트를 생산적으로 쓰기 위해 필요한 것은 더 많은 terminal pane이 아니라 명확한 task identity, attention routing, write ownership, recovery boundary입니다.
+
+이번 MacBook local design에서는 cmux를 primary workspace와 attention cockpit으로 선택했습니다. Ghostty는 신뢰할 수 있는 fallback terminal로 남기고, tmux는 cmux 종료 후에도 유지해야 하는 장기 interactive process에만 사용합니다. native subagent와 one-shot worker에는 tmux를 요구하지 않습니다.
+
+가장 중요한 운영 원칙은 복원 기능을 과대평가하지 않는 것입니다. cmux는 layout과 metadata를 되살리고, 지원되는 agent는 native session을 resume할 수 있습니다. 그러나 임의의 live process를 checkpoint하지 않습니다. tmux도 local server가 살아 있는 동안만 process를 유지하며 MacBook reboot를 넘지 못합니다. agent resume은 context recovery이고 live execution checkpoint가 아닙니다.
+
+마지막으로 workspace group, 이름, 색상은 실수를 줄이는 organization layer입니다. 보안 경계는 아닙니다. DevSecOps 관점의 Agentic Development Environment는 보기 좋은 cockpit에서 끝나지 않고, 최소 권한, secret 분리, single-writer rule, 검증 가능한 recovery runbook까지 포함할 때 비로소 운영 가능한 환경이 됩니다.
+
+---
+
+## 11. References
+
+- [Ghostty Docs - About Ghostty](https://ghostty.org/docs/about)
+- [Ghostty Docs - macOS Secure Input](https://ghostty.org/docs/config/reference#macos-auto-secure-input)
+- [cmux Docs - Getting Started](https://cmux.com/docs/getting-started)
+- [cmux Docs - Concepts](https://cmux.com/docs/concepts)
+- [cmux Docs - Workspace Groups](https://cmux.com/docs/workspace-groups)
+- [cmux Docs - Session Restore](https://cmux.com/docs/session-restore)
+- [cmux Docs - Notifications](https://cmux.com/docs/notifications)
+- [tmux Wiki - Getting Started](https://github.com/tmux/tmux/wiki/Getting-Started)
+- [tmux Wiki - FAQ](https://github.com/tmux/tmux/wiki/FAQ)
+- [Zellij User Guide - Session Resurrection](https://zellij.dev/documentation/session-resurrection.html)
+- [WezTerm Docs - Multiplexing](https://wezterm.org/multiplexing.html)
+- [WezTerm Docs - Bell Event](https://wezterm.org/config/lua/window-events/bell.html)
+- [kitty Docs - Remote Control](https://sw.kovidgoyal.net/kitty/remote-control/)
+- [kitty Docs - Desktop Notifications](https://sw.kovidgoyal.net/kitty/kittens/notify/)
+
+> **궁금하신 점이나 추가해야 할 부분은 댓글이나 아래의 링크를 통해 문의해주세요.**  
+> **Written with [KKamJi](https://www.linkedin.com/in/taejikim/)**  
+{: .prompt-info}

--- a/_posts/cheat-sheet/2026-07-12-tmux-cheat-sheet.md
+++ b/_posts/cheat-sheet/2026-07-12-tmux-cheat-sheet.md
@@ -1,0 +1,423 @@
+---
+title: tmux Command Cheat Sheet
+date: 2026-07-12 02:30:00 +0900
+author: kkamji
+categories: [System, Linux]
+tags: [tmux, terminal, shell, zsh, macos, linux, devops, cli, cheat-sheet] # TAG names should always be lowercase
+comments: true
+image:
+  path: /assets/img/kkam-img/kkam.webp
+---
+
+`tmux`는 하나의 터미널에서 여러 터미널을 만들고, 실행 중인 프로그램을 화면에서 분리했다가 다시 연결할 수 있게 하는 터미널 멀티플렉서입니다. 이 글에서는 macOS와 Linux에서 장시간 실행되는 대화형 AI 코딩 에이전트를 안전하게 다루는 데 필요한 명령과 기본 단축키를 정리합니다.
+
+---
+
+## 1. 핵심 개념
+
+tmux는 다음 계층으로 동작합니다.
+
+| 구성 요소 | 역할 |
+|---|---|
+| Server | 세션, 창, 패널과 그 안의 프로세스를 관리하는 백그라운드 프로세스 |
+| Client | 현재 터미널을 특정 세션에 연결하는 화면 |
+| Session | 하나 이상의 창을 묶는 작업 단위 |
+| Window | 세션 안의 전체 화면 단위이며 하나 이상의 패널을 포함 |
+| Pane | 셸이나 대화형 프로그램이 실행되는 개별 pseudo-terminal(PTY) |
+
+`detach`는 client만 session에서 분리합니다. session과 pane 안의 프로세스는 tmux server가 살아 있는 동안 계속 실행되며, 나중에 다시 `attach`할 수 있습니다. 반면 `kill-session`, 호스트 재부팅, tmux server 종료는 같은 의미가 아닙니다. tmux는 프로세스 체크포인트나 재부팅 복구 도구가 아니므로 중요한 상태는 애플리케이션 자체 파일이나 로그에도 남겨야 합니다.
+
+tmux는 Claude Code, Codex, Hermes 같은 대화형 프로그램에 지속적인 PTY를 제공할 뿐입니다. 작업을 분해하거나 subagent를 생성하고, 권한을 통제하거나, 여러 에이전트의 파일 수정을 조정하는 관리자는 아닙니다. 이러한 책임은 각 에이전트 도구와 사용자의 작업 절차에 남습니다.
+
+---
+
+## 2. 설치 및 확인
+
+### 2.1. 설치 여부와 버전 확인
+
+```shell
+command -v tmux
+tmux -V
+man 1 tmux
+```
+
+`command -v tmux`가 경로를 출력하지 않으면 운영체제의 패키지 관리자로 설치합니다.
+
+### 2.2. macOS
+
+```shell
+brew install tmux
+```
+
+### 2.3. Debian/Ubuntu
+
+```shell
+sudo apt update
+sudo apt install tmux
+```
+
+### 2.4. Fedora
+
+```shell
+sudo dnf install tmux
+```
+
+배포판 저장소의 버전은 최신 tmux 릴리스보다 오래될 수 있습니다. 사용 가능한 기능은 `tmux -V`, `man 1 tmux`, `tmux list-commands`로 현재 설치본을 기준으로 확인하는 것이 안전합니다.
+
+---
+
+## 3. Session 생명주기
+
+```shell
+# 이름을 지정하여 session 생성 후 바로 attach
+tmux new-session -s ai-work
+
+# 현재 디렉터리에서 detached session 생성
+tmux new-session -d -s ai-work -c "$PWD"
+
+# 같은 이름이 있으면 attach하고, 없으면 생성
+tmux new-session -A -s ai-work
+
+# session 목록 확인
+tmux list-sessions
+tmux ls
+
+# 지정한 session에 attach
+tmux attach-session -t ai-work
+tmux attach -t ai-work
+
+# 현재 client를 session에서 detach
+tmux detach-client
+
+# 특정 session에 연결된 모든 client를 detach
+tmux detach-client -s ai-work
+
+# session 이름 변경
+tmux rename-session -t ai-work incident-review
+
+# 지정한 session 종료
+tmux kill-session -t incident-review
+```
+
+tmux 내부에서는 기본 prefix인 `Ctrl-b`를 누른 뒤 `d`를 눌러 detach하는 방법이 가장 간단합니다. `Ctrl-b d`는 동시에 누르는 chord가 아니라 `Ctrl-b`를 놓고 `d`를 누르는 순차 입력입니다.
+
+`tmux attach-session -d -t ai-work`는 다른 client를 먼저 detach하고 현재 터미널을 연결합니다. 다른 터미널에서 같은 session을 보고 있을 수 있으므로 의도적으로 화면을 가져와야 할 때만 `-d`를 사용합니다.
+
+---
+
+## 4. Window와 Pane 관리
+
+### 4.1. 명령어
+
+```shell
+# window 생성, 목록, 이름 변경, 종료
+tmux new-window -t ai-work: -n logs -c "$PWD"
+tmux list-windows -t ai-work
+tmux rename-window -t ai-work:1 agent
+tmux kill-window -t ai-work:1
+
+# 현재 pane을 좌우로 분할
+tmux split-window -h
+
+# 현재 pane을 위아래로 분할
+tmux split-window -v
+
+# 모든 pane과 현재 명령 확인
+tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} pid=#{pane_pid} cmd=#{pane_current_command}'
+
+# 지정한 pane 선택, 확대 전환, 종료
+tmux select-pane -t ai-work:0.1
+tmux resize-pane -Z -t ai-work:0.1
+tmux kill-pane -t ai-work:0.1
+```
+
+대상은 일반적으로 `session:window.pane` 형식으로 지정합니다. 스크립트나 삭제 명령에서는 `ai-work:0.1`처럼 가능한 한 완전한 대상을 사용해야 이름과 인덱스의 모호성을 줄일 수 있습니다.
+
+### 4.2. 필수 기본 단축키
+
+아래 표의 키는 먼저 `Ctrl-b`를 누른 뒤 입력합니다.
+
+| 키 | 동작 |
+|---|---|
+| `c` | 새 window 생성 |
+| `,` | 현재 window 이름 변경 |
+| `&` | 현재 window 종료 확인 |
+| `n` / `p` | 다음 / 이전 window로 이동 |
+| `0`부터 `9` | 해당 인덱스의 window 선택 |
+| `w` | session과 window를 트리에서 선택 |
+| `"` | pane을 위아래로 분할 |
+| `%` | pane을 좌우로 분할 |
+| 방향키 | 인접 pane 선택 |
+| `o` | 다음 pane 선택 |
+| `q` | pane 인덱스 표시 |
+| `z` | 현재 pane 확대 상태 전환 |
+| `x` | 현재 pane 종료 확인 |
+| `Space` | 미리 정의된 pane layout 순환 |
+| `d` | 현재 client detach |
+| `s` | session을 대화형으로 선택 |
+| `[` | copy-mode 진입 |
+| `]` | 최근 tmux paste buffer 붙여넣기 |
+| `:` | tmux command prompt 열기 |
+| `?` | 현재 key binding 목록 보기 |
+
+애플리케이션에 prefix 자체를 보내야 하거나 중첩된 tmux의 안쪽 server에 명령하려면 `Ctrl-b Ctrl-b`를 사용합니다.
+
+---
+
+## 5. Copy-mode와 검색
+
+`Ctrl-b [`로 copy-mode에 들어가면 현재 화면뿐 아니라 pane history를 탐색할 수 있습니다. 기본 키 표는 `mode-keys` 옵션에 따라 emacs 또는 vi 방식으로 달라집니다.
+
+```shell
+# 현재 설정과 실제 key binding 확인
+tmux show-options -gw mode-keys
+tmux list-keys -T copy-mode
+tmux list-keys -T copy-mode-vi
+
+# tmux paste buffer 확인과 출력
+tmux list-buffers
+tmux show-buffer
+```
+
+| 작업 | emacs key table | vi key table |
+|---|---|---|
+| 앞으로 검색 | `Ctrl-s` | `/` |
+| 뒤로 검색 | `Ctrl-r` | `?` |
+| 같은 방향으로 다시 검색 | `n` | `n` |
+| 반대 방향으로 다시 검색 | `N` | `N` |
+| 선택 시작 | `Ctrl-Space` | `Space` |
+| 선택 복사 후 종료 | `Alt-w` | `Enter` |
+| copy-mode 종료 | `q` | `q` |
+
+복사한 내용은 tmux paste buffer에 들어가며, `Ctrl-b ]`로 pane에 붙여넣을 수 있습니다. 운영체제 clipboard 연동 여부는 tmux 옵션과 터미널 지원에 따라 달라지므로 tmux buffer 복사를 곧바로 시스템 clipboard 복사로 가정하면 안 됩니다.
+
+pane history는 무제한 감사 로그가 아닙니다. 현재 제한은 다음 명령으로 확인할 수 있으며, 장기 보존이 필요하면 에이전트 자체 기록이나 별도 로그를 사용합니다.
+
+```shell
+tmux show-options -gv history-limit
+```
+
+---
+
+## 6. zsh 함수와 별칭
+
+다음 내용을 `~/.zshrc`에 추가하면 자주 쓰는 작업을 짧게 실행할 수 있습니다. 모든 session 이름은 인용해 word splitting과 glob 확장을 막고, 종료 함수는 대상 존재 여부와 사용자 확인을 거칩니다.
+
+```zsh
+# 지정한 session을 생성하거나 attach합니다. 기본 이름은 work입니다.
+tm() {
+  local session_name="${1:-work}"
+  tmux new-session -A -s "$session_name"
+}
+
+# 모든 session을 표시합니다.
+tml() {
+  tmux list-sessions
+}
+
+# 기존 session에 attach합니다.
+tma() {
+  if (( $# != 1 )); then
+    print -u2 -- "Usage: tma <session-name>"
+    return 2
+  fi
+
+  tmux attach-session -t "$1"
+}
+
+# 확인 후 기존 session을 종료합니다.
+tmk() {
+  if (( $# != 1 )); then
+    print -u2 -- "Usage: tmk <session-name>"
+    return 2
+  fi
+
+  if ! tmux has-session -t "$1" 2>/dev/null; then
+    print -u2 -- "Session not found: $1"
+    return 1
+  fi
+
+  local reply
+  printf "Kill tmux session '%s'? [y/N] " "$1"
+  read -r reply
+  if [[ "$reply" != [yY] ]]; then
+    print -- "Canceled."
+    return 1
+  fi
+
+  tmux kill-session -t "$1"
+}
+
+# 선택 사항: 원래 명령을 가리지 않는 짧은 alias
+alias tls='tmux list-sessions'
+```
+
+```shell
+# 설정 다시 읽기
+source ~/.zshrc
+
+# 사용 예시
+tm ai-review
+tml
+tma ai-review
+tmk ai-review
+```
+
+`tm`은 기존 session이 있으면 그 session에 attach하므로 현재 디렉터리에서 새 session이 만들어질 것이라고 가정하면 안 됩니다. 새 session의 시작 디렉터리를 명시해야 한다면 직접 `tmux new-session -d -s NAME -c "$PWD"`를 사용합니다.
+
+---
+
+## 7. 상태 확인과 점검 명령
+
+```shell
+# server가 관리하는 session, client, window, pane 확인
+tmux list-sessions
+tmux list-clients
+tmux list-windows -a
+tmux list-panes -a
+
+# 읽기 쉬운 format으로 session 확인
+tmux list-sessions -F '#{session_name} attached=#{session_attached} windows=#{session_windows}'
+
+# 모든 window의 이름과 활성 상태 확인
+tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name} active=#{window_active} panes=#{window_panes}'
+
+# 현재 위치와 실행 중인 명령 확인
+tmux display-message -p '#S:#I.#P pid=#{pane_pid} cmd=#{pane_current_command}'
+
+# 지원 명령과 실제 key binding 확인
+tmux list-commands
+tmux list-keys -T prefix
+
+# global option과 server option 확인
+tmux show-options -g
+tmux show-options -s
+```
+
+`pane_current_command`는 pane의 현재 명령 이름을 보여주는 상태 정보입니다. 에이전트의 내부 작업 단계나 안전 상태를 증명하지 않으므로 종료 전에는 실제 화면과 애플리케이션 상태를 함께 확인해야 합니다.
+
+---
+
+## 8. 장시간 AI 코딩 세션 운영 예시
+
+### 8.1. 시작
+
+저장소마다 목적이 드러나는 session 이름을 사용하고, 작업 디렉터리를 명시해 detached 상태로 먼저 생성합니다.
+
+```shell
+cd ~/code/project
+tmux new-session -d -s project-agent -c "$PWD"
+tmux attach-session -t project-agent
+```
+
+한 window에는 하나의 주 작업 흐름을 두고, 빌드나 로그 확인은 별도 window 또는 pane으로 분리하면 문맥을 찾기 쉽습니다. 여러 에이전트가 같은 저장소를 동시에 수정할 때 tmux는 충돌을 방지하지 않습니다. 파일 소유권, branch 또는 worktree, 검증과 병합 순서는 별도로 정해야 합니다.
+
+### 8.2. 자리를 비우기 전
+
+1. 에이전트가 사용자 입력, 권한 승인, 충돌 해결을 기다리는지 확인합니다.
+2. 저장소 상태와 다음 작업을 기록하고, 필요한 결과가 파일에 저장되었는지 확인합니다.
+3. `Ctrl-b d`로 detach합니다.
+4. 외부 셸에서 `tmux list-sessions`로 session이 남아 있는지 확인합니다.
+
+detach는 현재 터미널 연결만 끊으므로 에이전트가 계속 명령을 실행할 수 있습니다. 승인 없이 계속 실행되면 안 되는 작업은 먼저 애플리케이션에서 안전하게 중단하거나 입력 대기 상태인지 확인합니다.
+
+### 8.3. 다시 연결한 뒤
+
+```shell
+tmux attach-session -t project-agent
+tmux display-message -p '#S:#I.#P pid=#{pane_pid} cmd=#{pane_current_command}'
+```
+
+화면 출력, prompt, 저장소 상태를 다시 확인한 뒤 입력을 이어갑니다. tmux가 PTY를 유지했다는 사실만으로 에이전트 요청이 성공했거나 저장소가 안전한 상태라고 판단하지 않습니다.
+
+---
+
+## 9. Compact Cheat Table
+
+| 목적 | 명령 또는 키 |
+|---|---|
+| 생성 후 attach | `tmux new-session -s NAME` |
+| 생성 또는 attach | `tmux new-session -A -s NAME` |
+| 목록 | `tmux ls` |
+| attach | `tmux attach -t NAME` |
+| detach | `Ctrl-b d` |
+| session 이름 변경 | `Ctrl-b $` |
+| 새 window | `Ctrl-b c` |
+| window 선택 | `Ctrl-b w` |
+| 좌우 분할 | `Ctrl-b %` |
+| 위아래 분할 | `Ctrl-b "` |
+| pane 선택 | `Ctrl-b 방향키` |
+| pane 확대 | `Ctrl-b z` |
+| copy-mode | `Ctrl-b [` |
+| buffer 붙여넣기 | `Ctrl-b ]` |
+| session 종료 | `tmux kill-session -t NAME` |
+
+---
+
+## 10. 자주 발생하는 문제
+
+### 10.1. `no server running` 메시지
+
+실행 중인 session이 없으면 기본 설정에서 tmux server도 종료됩니다. `tmux new-session -s NAME`으로 새 session을 생성합니다.
+
+### 10.2. 같은 이름의 session이 이미 존재함
+
+`tmux new-session -s NAME`은 중복 이름에서 실패합니다. 기존 session을 재사용하려면 `tmux attach -t NAME` 또는 `tmux new-session -A -s NAME`을 사용합니다.
+
+### 10.3. detach와 종료를 혼동함
+
+`Ctrl-b d`는 프로세스를 유지하지만 `exit`, `Ctrl-d`, `kill-pane`, `kill-window`, `kill-session`은 범위에 따라 프로세스를 종료할 수 있습니다. 장시간 실행 작업을 보존하려면 detach를 사용합니다.
+
+### 10.4. 재접속하면 새 환경 변수가 보이지 않음
+
+이미 실행 중인 프로세스의 환경은 attach만으로 교체되지 않습니다. credential이나 환경 변수를 갱신했다면 기존 에이전트에 자동 반영된다고 가정하지 말고, 필요한 프로세스를 정상 종료한 뒤 새 pane에서 다시 시작합니다. 민감한 값은 명령행, pane 출력, tmux buffer에 남기지 않습니다.
+
+### 10.5. 스크롤이 터미널처럼 동작하지 않음
+
+`Ctrl-b [`로 copy-mode에 진입해 history를 탐색합니다. 실제 키 표는 `tmux show-options -gw mode-keys`와 `tmux list-keys -T copy-mode-vi` 또는 `tmux list-keys -T copy-mode`로 확인합니다.
+
+### 10.6. 접속이 끊긴 뒤 session이 없음
+
+tmux는 같은 호스트에서 tmux server가 계속 살아 있을 때만 재연결할 수 있습니다. 호스트 재부팅, server 강제 종료, 마지막 session 종료 뒤에는 기존 프로세스를 복구하지 못합니다.
+
+---
+
+## 11. 안전한 정리
+
+먼저 대상과 실행 중인 명령을 확인합니다.
+
+```shell
+tmux list-sessions
+tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name} active=#{window_active}'
+tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} pid=#{pane_pid} cmd=#{pane_current_command}'
+```
+
+종료할 에이전트가 작업 중이거나 입력을 기다리는지 확인하고, 애플리케이션이 제공하는 정상 종료 방법을 먼저 사용합니다. 이후 남은 범위에 맞는 tmux 명령을 실행합니다.
+
+```shell
+# pane 하나만 종료
+tmux kill-pane -t project-agent:0.1
+
+# window 하나만 종료
+tmux kill-window -t project-agent:1
+
+# session 하나만 종료
+tmux kill-session -t project-agent
+
+# 지정한 session을 제외한 나머지 session 종료
+tmux kill-session -a -t keep-this
+```
+
+`tmux kill-session -a -t keep-this`와 `tmux kill-server`는 영향 범위가 큽니다. 특히 `tmux kill-server`는 해당 server의 모든 session과 client를 파괴하므로 일반적인 정리 명령으로 사용하지 않는 것이 안전합니다.
+
+---
+
+## 12. References
+
+- [OpenBSD Manual Pages - tmux(1)](https://man.openbsd.org/tmux.1)
+- [tmux Wiki - Getting Started](https://github.com/tmux/tmux/wiki/Getting-Started)
+- [tmux Wiki - Installing](https://github.com/tmux/tmux/wiki/Installing)
+
+> **궁금하신 점이나 추가해야 할 부분은 댓글이나 아래의 링크를 통해 문의해주세요.**  
+> **Written with [KKamJi](https://www.linkedin.com/in/taejikim/)**  
+{: .prompt-info}


### PR DESCRIPTION
## Summary
- Add a tmux command cheat sheet covering sessions, windows, panes, copy-mode, safe zsh helpers, and long-running interactive AI coding workflows.
- Add a MacBook-focused guide for building an Agentic Development Environment with cmux as the primary cockpit, Ghostty as fallback, and selective tmux persistence.

## Validation
- `kkamji_scripts/blog/run_md_tools.sh` applied to both target posts
- `bundle exec jekyll build` passed
- `gitleaks git --staged` passed
- GPT-5.6 Sol/high parallel drafting completed
- Claude Opus independent review passed
- hermac independent GitHub diff review passed

## Notes
- Markdown hard line breaks in prompt blocks and the required footer use trailing two spaces. This is intentional for the existing Jekyll post style.
